### PR TITLE
chore: Update RDS instance type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added EFS removal policy to `mlflow-fargate` module
 - remove AmazonSageMakerFullAccess from `multi_account_basic` template in the `sagemaker-templates-service-catalog` module
+- update MySQL instance to use T3 instance type
 
 ## v1.0.0
 

--- a/manifests/storage-modules.yaml
+++ b/manifests/storage-modules.yaml
@@ -35,7 +35,7 @@ parameters:
   - name: engine-version
     value: 8.0.35
   - name: instance-type
-    value: t2.small
+    value: t3.small
   - name: database-name
     value: mlflowdb
   - name: admin-username


### PR DESCRIPTION
## Describe your changes

I'm updating the instance type for the MySQL DB after getting this message from AWS:
> Starting March 11, 2024, Amazon RDS will begin disabling the creation of Amazon RDS for MySQL, MariaDB, and PostgreSQL database instances running on M4, R4, or T2 instance types. 

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
