### PR TITLE
fixed the depcreated go1.x runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+### **Added**
+
 - added EFS removal policy to `mlflow-fargate` module
 - added `batch_inference` template to the `sagemaker-templates-service-catalog` module
-- remove AmazonSageMakerFullAccess from `multi_account_basic` template in the `sagemaker-templates-service-catalog` module
+
+### **Changed**
+
 - update MySQL instance to use T3 instance type
+- fixed the deprecated `go1.x` lambda runtime to use the standard `al2023` runtime
+
+### **Removed**
+
+- remove AmazonSageMakerFullAccess from `multi_account_basic` template in the `sagemaker-templates-service-catalog` module
 - remove AmazonSageMakerFullAccess from `sagemaker-endpoint` module
 
 ## v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 - added EFS removal policy to `mlflow-fargate` module
-- added `batch_inference` template to the `sagemaker-templates-service-catalog` module
 
 ### **Changed**
 
 - update MySQL instance to use T3 instance type
-- fixed the deprecated `go1.x` lambda runtime to use the standard `al2023` runtime
+- upgrade `cdk_ecr_deployment` version to fix the deprecated `go1.x` lambda runtime
 
 ### **Removed**
 

--- a/modules/mlflow/mlflow-image/requirements.in
+++ b/modules/mlflow/mlflow-image/requirements.in
@@ -1,4 +1,4 @@
 aws-cdk-lib==2.130.0
 cdk-nag==2.28.27
 boto3==1.34.35
-cdk_ecr_deployment==3.0.31
+cdk_ecr_deployment==3.0.42

--- a/modules/mlflow/mlflow-image/requirements.txt
+++ b/modules/mlflow/mlflow-image/requirements.txt
@@ -27,7 +27,7 @@ botocore==1.34.40
     #   s3transfer
 cattrs==23.2.3
     # via jsii
-cdk-ecr-deployment==3.0.31
+cdk-ecr-deployment==3.0.42
     # via -r requirements.in
 cdk-nag==2.28.27
     # via -r requirements.in
@@ -44,7 +44,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsii==1.94.0
+jsii==1.96.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-kubectl-v20

--- a/modules/mlflow/mlflow-image/stack.py
+++ b/modules/mlflow/mlflow-image/stack.py
@@ -39,7 +39,6 @@ class MlflowImagePublishingStack(cdk.Stack):
             "ECRDeployment",
             src=ecr_deployment.DockerImageName(local_image.image_uri),
             dest=ecr_deployment.DockerImageName(self.image_uri),
-            build_image="public.ecr.aws/lambda/provided:al2023",
         )
 
         # Add CDK nag suppressions

--- a/modules/mlflow/mlflow-image/stack.py
+++ b/modules/mlflow/mlflow-image/stack.py
@@ -39,6 +39,7 @@ class MlflowImagePublishingStack(cdk.Stack):
             "ECRDeployment",
             src=ecr_deployment.DockerImageName(local_image.image_uri),
             dest=ecr_deployment.DockerImageName(self.image_uri),
+            build_image="public.ecr.aws/lambda/provided:al2023",
         )
 
         # Add CDK nag suppressions


### PR DESCRIPTION
## Describe your changes

When using `ECRDeployment` from `cdk_ecr_deployment` construct, there is a custom resource that gets deployed and uses the depcreated `go1.x` as the Lambda runtime. The latest direction is to use `al2023` images for go lang containers as the runtime.

Following is the error if we do not update the deprecated lambda runtime:
```
Resource handler returned message: "The runtime parameter of go1.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (provided.al2023) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 6a2ada3a-aea3-497a-950e-015da8886827)" (RequestToken: 8017ee62-a603-0b83-6c0e-d81e66f8eea5, HandlerErrorCode: InvalidRequest)
```

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [ ] If the change was to a module, I have added thorough tests
- [ ] If the change was to a module, I have added/updated the module's README.md
- [ ] If a module was added, I added a reference to the module to the repository's README.md
- [ ] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
