### PR TITLE
fix: Code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/yaml-lint-check.yml
+++ b/.github/workflows/yaml-lint-check.yml
@@ -1,4 +1,6 @@
 name: Check YAML Files
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/aiops-modules/security/code-scanning/13](https://github.com/awslabs/aiops-modules/security/code-scanning/13)

To fix the problem, you should add a `permissions` key set to the root of the workflow file (`.github/workflows/yaml-lint-check.yml`). This ensures that all jobs default to the least privilege required. The minimal privilege required for this workflow is `contents: read` (so that `actions/checkout` works). Place the following block after the `name:` and before the `on:` block (GitHub Actions expects this ordering, but placing it at the top/root level is the essential step). No other privileges are needed for this workflow. No additional methods, functions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
