### PR TITLE
chore: bump seed-farmer to 8.0.0

### DIFF
--- a/one-click-launch.yaml
+++ b/one-click-launch.yaml
@@ -205,7 +205,7 @@ Resources:
                 nodejs: 18
             pre_build:
               commands:
-                - pip install seed-farmer
+                - pip install seed-farmer>=8.0.0
                 - apt-get install jq git
                 - npm install -g aws-cdk
             build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-seed-farmer~=7.0.10
+seed-farmer~=8.0.0


### PR DESCRIPTION
## Summary
- Bump seed-farmer dependency from 7.0.10 to 8.0.0
- Pin seed-farmer version in one-click-launch.yaml to >=8.0.0

## Breaking Changes in seed-farmer 8.0.0
- Dropped Python 3.9 support (EOL October 2025). Python 3.10+ is now required.
- Updated urllib3 to >=2.6.0

## Files Changed
- `requirements.txt`: `seed-farmer~=7.0.10` → `seed-farmer~=8.0.0`
- `one-click-launch.yaml`: `pip install seed-farmer` → `pip install seed-farmer>=8.0.0`