### PR TITLE
chore: Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
-- `sagemaker-model-monitoring` now triggers a one-time baseline generation upon deployment 
-- update seedfarmer version to 8.0.0 
+## v3.2.0
+
+### **Added**
+
+### **Changed**
+
+- `sagemaker-model-monitoring` now triggers a one-time baseline generation upon deployment
+- update seedfarmer version to 8.0.0
 - fixed duplicate principal error in `sagemaker-templates` module when dev, pre-prod, and prod account IDs resolve to the same AWS account
 - fixed `sagemaker-templates` Model Deploy seed code incorrectly granting S3 permissions to a ManagedPolicy instead of a Role, which caused deployment failures with CDK 2.174.0+
 - update qs to 6.14.1 via npm override to address security vulnerability
 - pin @cdklabs/generative-ai-cdk-constructs to 0.1.311 to fix build compatibility
 - update starlette to 0.50.0 and fastapi to 0.128.0 to address security vulnerabilities
 - updated `sagemaker-templates` to try archiving when repo deletion fails
-
 
 ## v3.1.0
 

--- a/examples/manifests/event-bus-modules.yaml
+++ b/examples/manifests/event-bus-modules.yaml
@@ -1,5 +1,5 @@
 name: event-bus
-path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/event-bus?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/event-bus?ref=release/3.2.0&depth=1
 targetAccount: tooling
 parameters:
   - name: event_bus_name

--- a/examples/manifests/fmops-modules.yaml
+++ b/examples/manifests/fmops-modules.yaml
@@ -1,5 +1,5 @@
 name: jumpstart-hf-asrwhisper-endpoint
-path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/sagemaker-jumpstart-fm-endpoint?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/sagemaker-jumpstart-fm-endpoint?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: jump-start-model-name

--- a/examples/manifests/personas-modules.yaml
+++ b/examples/manifests/personas-modules.yaml
@@ -1,5 +1,5 @@
 name: personas
-path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/personas?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/personas?ref=release/3.2.0&depth=1
 parameters:
   - name: bucket-name
     value: my-bucket

--- a/examples/manifests/sagemaker-endpoints-modules.yaml
+++ b/examples/manifests/sagemaker-endpoints-modules.yaml
@@ -1,7 +1,7 @@
 # This is an example manifest group.
 # Replace the parameters with the parameters for your model below prior the deployment.
 name: endpoint
-path: git::https://github.com/awslabs/aiops-modules.git//sagemaker/fmops/sagemaker-endpoint?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//sagemaker/fmops/sagemaker-endpoint?ref=release/3.2.0&depth=1
 parameters:
   - name: sagemaker_project_id
     value: project-1

--- a/examples/manifests/sagemaker-hugging-face.yml
+++ b/examples/manifests/sagemaker-hugging-face.yml
@@ -1,5 +1,5 @@
 name: hugging-face-mistral-endpoint
-path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/sagemaker-hugging-face-endpoint?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/sagemaker-hugging-face-endpoint?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: hugging-face-model-id

--- a/examples/manifests/sagemaker-model-package-group-modules.yaml
+++ b/examples/manifests/sagemaker-model-package-group-modules.yaml
@@ -1,5 +1,5 @@
 name: source-model-package-group
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-package-group?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-package-group?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: model_package_group_name
@@ -18,7 +18,7 @@ parameters:
     value: test
 ---
 name: target-model-package-group
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-package-group?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-package-group?ref=release/3.2.0&depth=1
 targetAccount: tooling
 parameters:
   - name: model_package_group_name

--- a/examples/manifests/sagemaker-model-package-promote-pipeline-modules.yaml
+++ b/examples/manifests/sagemaker-model-package-promote-pipeline-modules.yaml
@@ -1,5 +1,5 @@
 name: model-pipeline
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-package-promote-pipeline?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-package-promote-pipeline?ref=release/3.2.0&depth=1
 targetAccount: tooling
 parameters:
   - name: source_model_package_group_arn

--- a/examples/manifests/sagemaker-notebook-modules.yaml
+++ b/examples/manifests/sagemaker-notebook-modules.yaml
@@ -1,5 +1,5 @@
 name: notebook
-path: git::https://github.com/awslabs/aiops-modules.git//modules/modules/sagemaker/sagemaker-notebook?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/modules/sagemaker/sagemaker-notebook?ref=release/3.2.0&depth=1
 parameters:
   - name: notebook_name
     value: dummy

--- a/examples/manifests/sagemaker-templates-modules-codecommit.yaml
+++ b/examples/manifests/sagemaker-templates-modules-codecommit.yaml
@@ -1,5 +1,5 @@
 name: service-catalog
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: repository-type

--- a/examples/manifests/sagemaker-templates-modules-github.yaml
+++ b/examples/manifests/sagemaker-templates-modules-github.yaml
@@ -1,5 +1,5 @@
 name: service-catalog
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: repository-type

--- a/examples/sagemaker-ground-truth-labeling/image_bounding_box/sagemaker-ground-truth-labeling.yaml
+++ b/examples/sagemaker-ground-truth-labeling/image_bounding_box/sagemaker-ground-truth-labeling.yaml
@@ -1,5 +1,5 @@
 name: ground-truth-labeling
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: job_name

--- a/examples/sagemaker-ground-truth-labeling/image_multi_label_classification/sagemaker-ground-truth-labeling.yaml
+++ b/examples/sagemaker-ground-truth-labeling/image_multi_label_classification/sagemaker-ground-truth-labeling.yaml
@@ -1,5 +1,5 @@
 name: ground-truth-labeling
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: job_name

--- a/examples/sagemaker-ground-truth-labeling/image_semantic_segmentation/sagemaker-ground-truth-labeling.yaml
+++ b/examples/sagemaker-ground-truth-labeling/image_semantic_segmentation/sagemaker-ground-truth-labeling.yaml
@@ -1,5 +1,5 @@
 name: ground-truth-labeling
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: job_name

--- a/examples/sagemaker-ground-truth-labeling/image_single_label_classification/sagemaker-ground-truth-labeling.yaml
+++ b/examples/sagemaker-ground-truth-labeling/image_single_label_classification/sagemaker-ground-truth-labeling.yaml
@@ -1,5 +1,5 @@
 name: ground-truth-labeling
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: job_name

--- a/examples/sagemaker-ground-truth-labeling/named_entity_recognition/sagemaker-ground-truth-labeling.yaml
+++ b/examples/sagemaker-ground-truth-labeling/named_entity_recognition/sagemaker-ground-truth-labeling.yaml
@@ -1,5 +1,5 @@
 name: ground-truth-labeling
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: job_name

--- a/examples/sagemaker-ground-truth-labeling/text_multi_label_classification/sagemaker-ground-truth-labeling.yaml
+++ b/examples/sagemaker-ground-truth-labeling/text_multi_label_classification/sagemaker-ground-truth-labeling.yaml
@@ -1,5 +1,5 @@
 name: ground-truth-labeling
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: job_name

--- a/examples/sagemaker-ground-truth-labeling/text_single_label_classification/sagemaker-ground-truth-labeling.yaml
+++ b/examples/sagemaker-ground-truth-labeling/text_single_label_classification/sagemaker-ground-truth-labeling.yaml
@@ -1,5 +1,5 @@
 name: ground-truth-labeling
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-ground-truth-labeling?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: job_name

--- a/manifests/bedrock-finetuning-sfn/bedrock-finetuning-modules.yaml
+++ b/manifests/bedrock-finetuning-sfn/bedrock-finetuning-modules.yaml
@@ -1,5 +1,5 @@
 name: bedrock-finetuning
-path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/bedrock-finetuning?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/bedrock-finetuning?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: bedrock-base-model-ID

--- a/manifests/deepseek-sagemaker/sagemaker-endpoints-modules.yaml
+++ b/manifests/deepseek-sagemaker/sagemaker-endpoints-modules.yaml
@@ -1,5 +1,5 @@
 name: deepseek-jumpstart
-path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/sagemaker-jumpstart-fm-endpoint?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/sagemaker-jumpstart-fm-endpoint?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: jump-start-model-name

--- a/manifests/deepseek-sagemaker/sagemaker-studio-modules.yaml
+++ b/manifests/deepseek-sagemaker/sagemaker-studio-modules.yaml
@@ -1,5 +1,5 @@
 name: studio
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: vpc_id

--- a/manifests/eks-strands-agents-demo/core-modules.yaml
+++ b/manifests/eks-strands-agents-demo/core-modules.yaml
@@ -1,5 +1,5 @@
 name: eks
-path: git::https://github.com/awslabs/aiops-modules.git//modules/agents/eks-strands-agents-demo?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/agents/eks-strands-agents-demo?ref=release/3.2.0&depth=1
 parameters:
   - name: EksClusterName
     value: eks-strands-agents-demo

--- a/manifests/fine-tuning-6b/images-modules.yaml
+++ b/manifests/fine-tuning-6b/images-modules.yaml
@@ -1,5 +1,5 @@
 name: ray
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-image?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-image?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: EcrRepoName

--- a/manifests/fine-tuning-6b/ray-cluster-modules.yaml
+++ b/manifests/fine-tuning-6b/ray-cluster-modules.yaml
@@ -1,5 +1,5 @@
 name: ray-cluster
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-cluster?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-cluster?ref=release/3.2.0&depth=1
 parameters:
   - name: EksClusterAdminRoleArn
     valueFrom:

--- a/manifests/fine-tuning-6b/ray-operator-modules.yaml
+++ b/manifests/fine-tuning-6b/ray-operator-modules.yaml
@@ -1,5 +1,5 @@
 name: ray-operator
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-operator?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-operator?ref=release/3.2.0&depth=1
 parameters:
   - name: EksClusterAdminRoleArn
     valueFrom:

--- a/manifests/fine-tuning-6b/ray-orchestrator-modules.yaml
+++ b/manifests/fine-tuning-6b/ray-orchestrator-modules.yaml
@@ -1,5 +1,5 @@
 name: ray-orchestrator
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-orchestrator?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-orchestrator?ref=release/3.2.0&depth=1
 parameters:
   - name: Namespace
     valueFrom:

--- a/manifests/fmops-qna-rag/qna-rag-modules.yaml
+++ b/manifests/fmops-qna-rag/qna-rag-modules.yaml
@@ -1,5 +1,5 @@
 name: qna-rag
-path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/qna-rag?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/fmops/qna-rag?ref=release/3.2.0&depth=1
 parameters:
   - name: cognito-pool-id
     # Replace below value with valid congnito pool id

--- a/manifests/hyperpod-eks/hyperpod-modules.yaml
+++ b/manifests/hyperpod-eks/hyperpod-modules.yaml
@@ -1,5 +1,5 @@
 name: hp
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/hyperpod-eks-tf?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/hyperpod-eks-tf?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: AvailabilityZoneId

--- a/manifests/mlflow-tracking/images-ai-gw-modules.yaml
+++ b/manifests/mlflow-tracking/images-ai-gw-modules.yaml
@@ -1,5 +1,5 @@
 name: mlflow-ai-gw-image
-path: git::https://github.com/awslabs/aiops-modules.git//modules/mlflow/mlflow-ai-gw-image?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/mlflow/mlflow-ai-gw-image?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: ecr-repository-name

--- a/manifests/mlflow-tracking/images-modules.yaml
+++ b/manifests/mlflow-tracking/images-modules.yaml
@@ -1,5 +1,5 @@
 name: mlflow-image
-path: git::https://github.com/awslabs/aiops-modules.git//modules/mlflow/mlflow-image?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/mlflow/mlflow-image?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: ecr-repository-name

--- a/manifests/mlflow-tracking/mlflow-modules.yaml
+++ b/manifests/mlflow-tracking/mlflow-modules.yaml
@@ -1,5 +1,5 @@
 name: mlflow-fargate
-path: git::https://github.com/awslabs/aiops-modules.git//modules/mlflow/mlflow-fargate?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/mlflow/mlflow-fargate?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: vpc-id

--- a/manifests/mlflow-tracking/sagemaker-studio-modules.yaml
+++ b/manifests/mlflow-tracking/sagemaker-studio-modules.yaml
@@ -1,5 +1,5 @@
 name: studio
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: vpc_id

--- a/manifests/mlops-sagemaker-multiacc/kernels-modules.yaml
+++ b/manifests/mlops-sagemaker-multiacc/kernels-modules.yaml
@@ -1,5 +1,5 @@
 name: sagemaker-custom-kernel
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-custom-kernel?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-custom-kernel?ref=release/3.2.0&depth=1
 targetAccount: dev
 parameters:
   - name: ecr-repo-name

--- a/manifests/mlops-sagemaker-multiacc/sagemaker-model-cicd-modules.yaml
+++ b/manifests/mlops-sagemaker-multiacc/sagemaker-model-cicd-modules.yaml
@@ -1,5 +1,5 @@
 name: model  # replace with name of the ML model you prefer
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-cicd?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-model-cicd?ref=release/3.2.0&depth=1
 targetAccount: tooling
 parameters:
   - name: infra-repo

--- a/manifests/mlops-sagemaker-multiacc/sagemaker-studio-modules.yaml
+++ b/manifests/mlops-sagemaker-multiacc/sagemaker-studio-modules.yaml
@@ -1,5 +1,5 @@
 name: studio
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.2.0&depth=1
 targetAccount: dev
 parameters:
   - name: vpc_id

--- a/manifests/mlops-sagemaker-multiacc/sagemaker-templates-modules.yaml
+++ b/manifests/mlops-sagemaker-multiacc/sagemaker-templates-modules.yaml
@@ -1,5 +1,5 @@
 name: service-catalog
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.2.0&depth=1
 targetAccount: dev
 parameters:
   - name: portfolio-access-role-arn

--- a/manifests/mlops-sagemaker/sagemaker-studio-modules.yaml
+++ b/manifests/mlops-sagemaker/sagemaker-studio-modules.yaml
@@ -1,5 +1,5 @@
 name: studio
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-studio?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: vpc_id

--- a/manifests/mlops-sagemaker/sagemaker-templates-factory-modules.yaml
+++ b/manifests/mlops-sagemaker/sagemaker-templates-factory-modules.yaml
@@ -1,5 +1,5 @@
 name: templates-xgboost
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: project_template_type
@@ -38,7 +38,7 @@ parameters:
   #   value: False
 ---
 name: templates-batch
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: project_template_type
@@ -79,7 +79,7 @@ parameters:
     value: batch-1
 ---
 name: templates-deploy
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: project_template_type
@@ -156,7 +156,7 @@ parameters:
     value: true
 ---
 name: templates-hf
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: project_template_type
@@ -195,7 +195,7 @@ parameters:
     value: model-1
 ---
 name: templates-finetune-llm
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-templates-service-catalog?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: project_template_type

--- a/manifests/mlops-stepfunctions/mlops-stepfunctions.yaml
+++ b/manifests/mlops-stepfunctions/mlops-stepfunctions.yaml
@@ -1,5 +1,5 @@
 name: stepfunctions
-path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/mlops-stepfunctions?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/mlops-stepfunctions?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: model-name

--- a/manifests/mwaa-ml-training/mwaa-dag-modules.yaml
+++ b/manifests/mwaa-ml-training/mwaa-dag-modules.yaml
@@ -1,5 +1,5 @@
 name: dags
-path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/airflow-dags?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/examples/airflow-dags?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: dag-bucket-name

--- a/manifests/ray-on-eks/images-modules.yaml
+++ b/manifests/ray-on-eks/images-modules.yaml
@@ -1,5 +1,5 @@
 name: ray
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-image?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-image?ref=release/3.2.0&depth=1
 targetAccount: primary
 parameters:
   - name: EcrRepoName

--- a/manifests/ray-on-eks/ray-cluster-modules.yaml
+++ b/manifests/ray-on-eks/ray-cluster-modules.yaml
@@ -1,5 +1,5 @@
 name: ray-cluster
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-cluster?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-cluster?ref=release/3.2.0&depth=1
 parameters:
   - name: EksClusterAdminRoleArn
     valueFrom:

--- a/manifests/ray-on-eks/ray-operator-modules.yaml
+++ b/manifests/ray-on-eks/ray-operator-modules.yaml
@@ -1,5 +1,5 @@
 name: ray-operator
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-operator?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-operator?ref=release/3.2.0&depth=1
 parameters:
   - name: EksClusterAdminRoleArn
     valueFrom:

--- a/manifests/ray-on-eks/ray-orchestrator-modules.yaml
+++ b/manifests/ray-on-eks/ray-orchestrator-modules.yaml
@@ -1,5 +1,5 @@
 name: ray-orchestrator
-path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-orchestrator?ref=release/3.1.0&depth=1
+path: git::https://github.com/awslabs/aiops-modules.git//modules/eks/ray-orchestrator?ref=release/3.2.0&depth=1
 parameters:
   - name: Namespace
     valueFrom:

--- a/one-click-launch.yaml
+++ b/one-click-launch.yaml
@@ -3,8 +3,8 @@ Description: Creates AIOps setup for Developers
 Parameters:
   VersionTag:
     Type: String
-    Default: v2.1.0
-    Description: Version. Should reference version tag in the repository e.g v2.1.0
+    Default: v3.2.0
+    Description: Version. Should reference version tag in the repository e.g v3.2.0
   ManifestPath:
     Type: String
     Default: manifests/mlops-sagemaker/deployment.yaml


### PR DESCRIPTION
## Summary

Release v3.2.0 with the following changes:

### Changed
- `sagemaker-model-monitoring` now triggers a one-time baseline generation upon deployment
- update seedfarmer version to 8.0.0
- fixed duplicate principal error in `sagemaker-templates` module when dev, pre-prod, and prod account IDs resolve to the same AWS account
- fixed `sagemaker-templates` Model Deploy seed code incorrectly granting S3 permissions to a ManagedPolicy instead of a Role, which caused deployment failures with CDK 2.174.0+
- update qs to 6.14.1 via npm override to address security vulnerability
- pin @cdklabs/generative-ai-cdk-constructs to 0.1.311 to fix build compatibility
- update starlette to 0.50.0 and fastapi to 0.128.0 to address security vulnerabilities
- updated `sagemaker-templates` to try archiving when repo deletion fails

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [ ] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.