### PR TITLE
chore: Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+## v3.2.1
+
+### **Added**
+
+### **Changed**
+
 - fixed duplicate principal error in `sagemaker-templates` KMS key and S3 bucket policies when dev, pre-prod, and prod account IDs resolve to the same AWS account
 
 ## v3.2.0


### PR DESCRIPTION
## Summary
- Release v3.2.1

## Changes

### Changed
- fixed duplicate principal error in `sagemaker-templates` KMS key and S3 bucket policies when dev, pre-prod, and prod account IDs resolve to the same AWS account

**Full Changelog**: https://github.com/awslabs/aiops-modules/compare/v3.2.0...release/v3.2.1