### PR TITLE
fix: add explicit permissions to workflow

### DIFF
--- a/.github/workflows/module-checks-dev-requirements-change.yml
+++ b/.github/workflows/module-checks-dev-requirements-change.yml
@@ -15,6 +15,9 @@ on:
     paths:
       - "requirements-dev.txt"
 
+permissions:
+  contents: read
+
 jobs:
   get-modules:
     name: Get Modules


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `module-checks-dev-requirements-change.yml` to restrict GITHUB_TOKEN scope following principle of least privilege

## Security
Resolves CodeQL code scanning alerts:
- [Alert #9](https://github.com/awslabs/aiops-modules/security/code-scanning/9) - `get-modules` job missing permissions
- [Alert #11](https://github.com/awslabs/aiops-modules/security/code-scanning/11) - `test` job missing permissions

## Test plan
- [x] Verify workflow still runs successfully on PRs
- [x] Verify CodeQL alerts are resolved after merge