### PR TITLE
feat: Add cross-account external ID support for CDK lookup role

### DIFF
--- a/modules/sagemaker/sagemaker-templates/settings.py
+++ b/modules/sagemaker/sagemaker-templates/settings.py
@@ -69,7 +69,7 @@ class ModuleSettings(CdkBaseSettings):
     prod_vpc_id: Optional[str] = Field(default=None)
     prod_subnet_ids: List[str] = Field(default=[])
     prod_security_group_ids: List[str] = Field(default=[])
-
+    cross_account_external_id: Optional[str] = Field(default=None)
     repository_type: RepositoryType = Field(default=RepositoryType.CODECOMMIT)
     access_token_secret_name: str = Field(default="github_token")
     aws_codeconnection_arn: Optional[str] = Field(default=None)

--- a/modules/sagemaker/sagemaker-templates/stack.py
+++ b/modules/sagemaker/sagemaker-templates/stack.py
@@ -51,6 +51,7 @@ class ProjectStack(Stack):
         batch_inference_project_settings: Any = None,
         permissions_boundary_name: Optional[str] = None,
         s3_access_logs_bucket_arn: Optional[str] = None,
+        cross_account_external_id: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -176,6 +177,7 @@ class ProjectStack(Stack):
                 access_token_secret_name=access_token_secret_name,
                 aws_codeconnection_arn=aws_codeconnection_arn,
                 repository_owner=repository_owner,
+                cross_account_external_id=cross_account_external_id,
             )
         else:
             raise ValueError(f"Unsupported project template type: {project_template_type}")

--- a/modules/sagemaker/sagemaker-templates/templates/model_deploy/product_stack.py
+++ b/modules/sagemaker/sagemaker-templates/templates/model_deploy/product_stack.py
@@ -93,6 +93,7 @@ class ModelDeployProject(Construct):
         prod_vpc_id: str = "",
         prod_subnet_ids: Optional[List[str]] = None,
         prod_security_group_ids: Optional[List[str]] = None,
+        cross_account_external_id: Optional[str] = None,
         sagemaker_domain_id: str = "",
         sagemaker_domain_arn: str = "",
         repository_type: RepositoryType = RepositoryType.CODECOMMIT,
@@ -162,6 +163,7 @@ class ModelDeployProject(Construct):
             "PROD_REGION": codebuild.BuildEnvironmentVariable(value=prod_region),
             "PROD_SUBNET_IDS": codebuild.BuildEnvironmentVariable(value=json.dumps(prod_subnet_ids)),
             "PROD_SECURITY_GROUP_IDS": codebuild.BuildEnvironmentVariable(value=json.dumps(prod_security_group_ids)),
+            "CROSS_ACCOUNT_EXTERNAL_ID": codebuild.BuildEnvironmentVariable(value=cross_account_external_id or ""),
             "ENABLE_NETWORK_ISOLATION": codebuild.BuildEnvironmentVariable(value=str(enable_network_isolation).lower()),
             "ENABLE_MANUAL_APPROVAL": codebuild.BuildEnvironmentVariable(value=str(enable_manual_approval).lower()),
             "ENABLE_EVENTBRIDGE_TRIGGER": codebuild.BuildEnvironmentVariable(

--- a/modules/sagemaker/sagemaker-templates/templates/model_deploy/seed_code/deploy_app/config/constants.py
+++ b/modules/sagemaker/sagemaker-templates/templates/model_deploy/seed_code/deploy_app/config/constants.py
@@ -59,6 +59,10 @@ DOMAIN_ARN = os.getenv("DOMAIN_ARN", None)
 ECR_REPO_ARN = os.getenv("ECR_REPO_ARN", None)
 
 ENABLE_NETWORK_ISOLATION = get_bool_env("ENABLE_NETWORK_ISOLATION", default=True)
+# Only used for the CDK lookup role (Vpc.from_lookup during cdk synth).
+# CodePipeline does not support externalId on action roles, so this cannot
+# be applied to the deploy role.
+CROSS_ACCOUNT_EXTERNAL_ID = os.getenv("CROSS_ACCOUNT_EXTERNAL_ID", "")
 ENABLE_MANUAL_APPROVAL = get_bool_env("ENABLE_MANUAL_APPROVAL", default=True)
 ENABLE_EVENTBRIDGE_TRIGGER = get_bool_env("ENABLE_EVENTBRIDGE_TRIGGER", default=True)
 ENABLE_DATA_CAPTURE = get_bool_env("ENABLE_DATA_CAPTURE", default=True)

--- a/modules/sagemaker/sagemaker-templates/templates/model_deploy/seed_code/deploy_app/deploy_app/pipeline_stack.py
+++ b/modules/sagemaker/sagemaker-templates/templates/model_deploy/seed_code/deploy_app/deploy_app/pipeline_stack.py
@@ -41,6 +41,7 @@ ENV = {
     "ENABLE_MANUAL_APPROVAL": str(constants.ENABLE_MANUAL_APPROVAL).lower(),
     "ENABLE_EVENTBRIDGE_TRIGGER": str(constants.ENABLE_EVENTBRIDGE_TRIGGER).lower(),
     "ENABLE_DATA_CAPTURE": str(constants.ENABLE_DATA_CAPTURE).lower(),
+    "CROSS_ACCOUNT_EXTERNAL_ID": constants.CROSS_ACCOUNT_EXTERNAL_ID,
 }
 
 
@@ -54,9 +55,16 @@ class DeployStage(cdk.Stage):
         vpc_id: str,
         subnet_ids: list[str],
         security_group_ids: list[str],
+        lookup_role_external_id: str = "",
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
+
+        synthesizer = None
+        if lookup_role_external_id:
+            synthesizer = cdk.DefaultStackSynthesizer(
+                lookup_role_external_id=lookup_role_external_id,
+            )
 
         DeployEndpointStack(
             self,
@@ -65,6 +73,7 @@ class DeployStage(cdk.Stage):
             vpc_id=vpc_id,
             subnet_ids=subnet_ids,
             security_group_ids=security_group_ids,
+            synthesizer=synthesizer,
         )
 
 
@@ -192,6 +201,7 @@ class PipelineStack(cdk.Stack):
                 vpc_id=constants.PRE_PROD_VPC_ID,
                 subnet_ids=constants.PRE_PROD_SUBNET_IDS,
                 security_group_ids=constants.PRE_PROD_SECURITY_GROUP_IDS,
+                lookup_role_external_id=constants.CROSS_ACCOUNT_EXTERNAL_ID,
                 env=cdk.Environment(account=constants.PRE_PROD_ACCOUNT_ID, region=constants.PRE_PROD_REGION),
             ),
             pre=[ManualApprovalStep("ApprovePreProd", comment="Approve deployment to Pre-Production")]
@@ -207,6 +217,7 @@ class PipelineStack(cdk.Stack):
                 vpc_id=constants.PROD_VPC_ID,
                 subnet_ids=constants.PROD_SUBNET_IDS,
                 security_group_ids=constants.PROD_SECURITY_GROUP_IDS,
+                lookup_role_external_id=constants.CROSS_ACCOUNT_EXTERNAL_ID,
                 env=cdk.Environment(account=constants.PROD_ACCOUNT_ID, region=constants.PROD_REGION),
             ),
             pre=[ManualApprovalStep("ApproveProd", comment="Approve deployment to Production")]

--- a/modules/sagemaker/sagemaker-templates/templates/model_deploy/seed_code/deploy_app/requirements.txt
+++ b/modules/sagemaker/sagemaker-templates/templates/model_deploy/seed_code/deploy_app/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.128.0
+aws-cdk-lib==2.170.0
 constructs>=10.0.0,<11.0.0
 yamldataclassconfig


### PR DESCRIPTION
Add optional cross_account_external_id that flows from capability config to DefaultStackSynthesizer.lookupRoleExternalId. Only applies to the lookup role - CodePipeline does not support externalId on action roles.

Bumps aws-cdk-lib to 2.170.0 (required for lookupRoleExternalId).

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I updated `CHANGELOG.MD` with a description of my changes
- [ ] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [ ] If the change was to a module, I have added thorough tests
- [ ] If the change was to a module, I have added/updated the module's README.md
- [ ] If a module was added, I added a reference to the module to the repository's README.md
- [ ] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
